### PR TITLE
Add networking, default mode for shared kafka

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -1,6 +1,6 @@
 x-sentry-service-config:
   version: 0.1
-  service_name: kafka
+  service_name: shared-kafka
   dependencies:
     kafka:
       description: "A distributed data store optimized for ingesting and processing streaming data in real-time"
@@ -38,11 +38,14 @@ services:
       - '9092:9092'
       - '9093:9093'
     volumes:
-      - "sentry-kafka:/var/lib/kafka/data"
+      - "kafka-data:/var/lib/kafka/data"
     networks:
       - sentry
+    extra_hosts:
+      - "host.docker.internal:host-gateway" # Allow host.docker.internal to resolve to the host machine
+
 volumes:
-  sentry-kafka:
+  kafka-data:
 
 networks:
   sentry:

--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -47,4 +47,4 @@ volumes:
 networks:
   sentry:
     name: sentry
-    external: true
+    # external: true

--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -38,13 +38,12 @@ services:
       - '9092:9092'
       - '9093:9093'
     volumes:
-      - "kafka:/var/lib/kafka/data"
+      - "sentry-kafka:/var/lib/kafka/data"
     networks:
       - sentry
 volumes:
-  kafka:
+  sentry-kafka:
 
 networks:
   sentry:
     name: sentry
-    # external: true

--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -1,12 +1,14 @@
 x-sentry-service-config:
   version: 0.1
   service_name: shared-kafka
-  dependencies: {}
+  dependencies:
+    shared-kafka:
+      description: "A distributed data store optimized for ingesting and processing streaming data in real-time"
   modes:
-    default: []
+    default: [shared-kafka]
 
 services:
-  kafka:
+  shared-kafka:
     image: "confluentinc/cp-kafka:7.6.1"
     environment:
       # https://docs.confluent.io/platform/current/installation/docker/config-reference.html#cp-kakfa-example

--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -9,40 +9,40 @@ x-sentry-service-config:
 
 services:
   kafka:
-    image: "confluentinc/cp-kafka:7.6.1"
+    image: ghcr.io/getsentry/image-mirror-confluentinc-cp-kafka:7.5.0
     environment:
       # https://docs.confluent.io/platform/current/installation/docker/config-reference.html#cp-kakfa-example
-      KAFKA_PROCESS_ROLES: "broker,controller"
-      KAFKA_CONTROLLER_QUORUM_VOTERS: "1001@127.0.0.1:29093"
-      KAFKA_CONTROLLER_LISTENER_NAMES: "CONTROLLER"
-      KAFKA_NODE_ID: "1001"
-      CLUSTER_ID: "MkU3OEVBNTcwNTJENDM2Qk"
-      KAFKA_LISTENERS: "PLAINTEXT://0.0.0.0:29092,INTERNAL://0.0.0.0:9093,EXTERNAL://0.0.0.0:9092,CONTROLLER://0.0.0.0:29093"
-      KAFKA_ADVERTISED_LISTENERS: "PLAINTEXT://127.0.0.1:29092,INTERNAL://kafka:9093,EXTERNAL://kafka:9092"
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: "PLAINTEXT:PLAINTEXT,INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT"
-      KAFKA_INTER_BROKER_LISTENER_NAME: "PLAINTEXT"
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "1"
-      KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS: "1"
-      KAFKA_LOG_RETENTION_HOURS: "24"
-      KAFKA_MESSAGE_MAX_BYTES: "50000000" #50MB or bust
-      KAFKA_MAX_REQUEST_SIZE: "50000000" #50MB on requests apparently too
-      CONFLUENT_SUPPORT_METRICS_ENABLE: "false"
-      KAFKA_LOG4J_LOGGERS: "kafka.cluster=WARN,kafka.controller=WARN,kafka.coordinator=WARN,kafka.log=WARN,kafka.server=WARN,state.change.logger=WARN"
-      KAFKA_LOG4J_ROOT_LOGLEVEL: "WARN"
-      KAFKA_TOOLS_LOG4J_LOGLEVEL: "WARN"
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1001@127.0.0.1:29093
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_NODE_ID: 1001
+      CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:29092,INTERNAL://0.0.0.0:9093,EXTERNAL://0.0.0.0:9092,CONTROLLER://0.0.0.0:29093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://127.0.0.1:29092,INTERNAL://kafka:9093,EXTERNAL://kafka:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_OFFSETS_TOPIC_NUM_PARTITIONS: 1
+      KAFKA_LOG_RETENTION_HOURS: 24
+      KAFKA_MESSAGE_MAX_BYTES: 50000000 # 50MB or bust
+      KAFKA_MAX_REQUEST_SIZE: 50000000 # 50MB on requests apparently too
+      CONFLUENT_SUPPORT_METRICS_ENABLE: false
+      KAFKA_LOG4J_LOGGERS: kafka.cluster=WARN,kafka.controller=WARN,kafka.coordinator=WARN,kafka.log=WARN,kafka.server=WARN,state.change.logger=WARN
+      KAFKA_LOG4J_ROOT_LOGLEVEL: WARN
+      KAFKA_TOOLS_LOG4J_LOGLEVEL: WARN
     ulimits:
       nofile:
         soft: 4096
         hard: 4096
     ports:
-      - '9092:9092'
-      - '9093:9093'
+      - 9092:9092
+      - 9093:9093
     volumes:
-      - "kafka-data:/var/lib/kafka/data"
+      - kafka-data:/var/lib/kafka/data
     networks:
       - sentry
     extra_hosts:
-      - "host.docker.internal:host-gateway" # Allow host.docker.internal to resolve to the host machine
+      - host.docker.internal:host-gateway # Allow host.docker.internal to resolve to the host machine
 
 volumes:
   kafka-data:

--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -1,14 +1,14 @@
 x-sentry-service-config:
   version: 0.1
-  service_name: shared-kafka
+  service_name: kafka
   dependencies:
-    shared-kafka:
+    kafka:
       description: "A distributed data store optimized for ingesting and processing streaming data in real-time"
   modes:
-    default: [shared-kafka]
+    default: [kafka]
 
 services:
-  shared-kafka:
+  kafka:
     image: "confluentinc/cp-kafka:7.6.1"
     environment:
       # https://docs.confluent.io/platform/current/installation/docker/config-reference.html#cp-kakfa-example
@@ -34,7 +34,17 @@ services:
       nofile:
         soft: 4096
         hard: 4096
+    ports:
+      - '9092:9092'
+      - '9093:9093'
     volumes:
       - "kafka:/var/lib/kafka/data"
+    networks:
+      - sentry
 volumes:
   kafka:
+
+networks:
+  sentry:
+    name: sentry
+    external: true


### PR DESCRIPTION
Docker compose requires external network to communicate with other compose projects across the docker network

Also adds default mode which was not defined before