### PR TITLE
chore(kafka): Only expose ports to localhost

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -35,8 +35,8 @@ services:
         soft: 4096
         hard: 4096
     ports:
-      - 9092:9092
-      - 9093:9093
+      - 127.0.0.1:9092:9092
+      - 127.0.0.1:9093:9093
     volumes:
       - kafka-data:/var/lib/kafka/data
     networks:


### PR DESCRIPTION
we shouldn't expose kafka to network, limit to localhost