### PR TITLE
Add restart settings and use external devservices network

### DIFF
--- a/devservices/config.yml
+++ b/devservices/config.yml
@@ -48,6 +48,7 @@ services:
       - devservices
     extra_hosts:
       - host.docker.internal:host-gateway # Allow host.docker.internal to resolve to the host machine
+    restart: unless-stopped
 
 volumes:
   kafka-data:
@@ -55,3 +56,4 @@ volumes:
 networks:
   devservices:
     name: devservices
+    external: true


### PR DESCRIPTION
restart settings: unless-stopped

use external devservices network for containers